### PR TITLE
BUG: Fix packaging of module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ include(${Slicer_USE_FILE})
 
 #-----------------------------------------------------------------------------
 # Extension modules
-add_subdirectory(DSCI_Anonymize)
+add_subdirectory(SlicerBatchAnonymize)
 ## NEXT_MODULE
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
The module had been updated with the new extension name resulting in the packaging of the module failing as observed in https://slicer.cdash.org/build/2586927/configure. Following up to this PR, you may consider giving the module name a more readable version without the prefix "Slicer" where this prefix is only needed for the extension name, not the modules name.